### PR TITLE
BEP Exploration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,8 @@
 build --repository_cache=/tmp/bazel/repository_cache
 build --disk_cache=/tmp/bazel/disk_cache
+test:bep_fixture --runs_per_test=10
+test:bep_fixture --runs_per_test_detects_flakes=true
+test:bep_fixture -t-
+test:bep_fixture --test_env=CREATE_XCRESULT_BUNDLE=1
+build:bes_server --bes_backend=grpc://localhost:9000
+build:bes_server --bes_upload_mode=fully_async

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY project_bep:
+project_bep:
+	bazelisk run //src/bep:project && open src/bep/project.xcodeproj
+
+.PHONY bes_server:
+bes_server:
+	bazelisk run //src/bep/BESServer:publish_build_event_server
+
+.PHONY build_bes:
+build_bes: target ?= placeholder
+build_bes:
+	bazelisk build $(target) --config=bes_server

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 A project exploring the use of Bazel and Swift across various use-cases.
 
+## Explorations
+
+- [Build Event Protocol Parsing via Protocol Buffers](src/bep)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,3 +63,12 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
+http_archive(
+    name = "com_github_bazelbuild_bazel",
+    patches = [
+        "//infra/patches:build_event_stream_java_proto.patch",
+    ],
+    sha256 = "06d3dbcba2286d45fc6479a87ccc649055821fc6da0c3c6801e73da780068397",
+    strip_prefix = "bazel-6.0.0",
+    url = "https://github.com/bazelbuild/bazel/archive/refs/tags/6.0.0.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,3 +72,11 @@ http_archive(
     strip_prefix = "bazel-6.0.0",
     url = "https://github.com/bazelbuild/bazel/archive/refs/tags/6.0.0.tar.gz",
 )
+
+http_archive(
+    name = "com_github_apple_swift_argument_parser",
+    build_file = "swift-argument-parser/BUILD",
+    sha256 = "44782ba7180f924f72661b8f457c268929ccd20441eac17301f18eff3b91ce0c",
+    strip_prefix = "swift-argument-parser-1.2.2",
+    url = "https://github.com/apple/swift-argument-parser/archive/refs/tags/1.2.2.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,3 +43,23 @@ load(
 )
 
 apple_support_dependencies()
+
+http_archive(
+    name = "com_github_bazelbuild_rules_proto",
+    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+    ],
+)
+
+load(
+    "@com_github_bazelbuild_rules_proto//proto:repositories.bzl",
+    "rules_proto_dependencies",
+    "rules_proto_toolchains",
+)
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,13 @@ load(
 
 xcodeproj_rules_dependencies()
 
+http_archive(
+    name = "build_bazel_rules_apple",
+    sha256 = "2e68d159b783046c497979a0275cea8ce7720b4cbf3db17f4e0de9586b27082a",
+    strip_prefix = "rules_apple-2fb221631dec5dfbbe650bd8a614237eb46cb7db",
+    url = "https://github.com/bazelbuild/rules_apple/archive/2fb221631dec5dfbbe650bd8a614237eb46cb7db.tar.gz",
+)
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",
@@ -71,6 +78,25 @@ http_archive(
     sha256 = "06d3dbcba2286d45fc6479a87ccc649055821fc6da0c3c6801e73da780068397",
     strip_prefix = "bazel-6.0.0",
     url = "https://github.com/bazelbuild/bazel/archive/refs/tags/6.0.0.tar.gz",
+)
+
+http_archive(
+    name = "com_google_googleapis",
+    patches = [
+        "//infra/patches:publish_build_event_proto.patch",
+    ],
+    sha256 = "18a735ec31b7767cabfce0a8f71e7e8e74c11aa18fbd50fbdc0db5b26c2f6278",
+    strip_prefix = "googleapis-f9d9c0418f10c2352fbe4515cac9e7072f9924a2",
+    url = "https://github.com/googleapis/googleapis/archive/f9d9c0418f10c2352fbe4515cac9e7072f9924a2.tar.gz",
+)
+
+load(
+    "@com_google_googleapis//:repository_rules.bzl",
+    "switched_rules_by_language",
+)
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
 )
 
 http_archive(

--- a/external/swift-argument-parser/BUILD
+++ b/external/swift-argument-parser/BUILD
@@ -1,0 +1,20 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "ArgumentParserToolInfo",
+    srcs = glob(["Sources/ArgumentParserToolInfo/**/*.swift"]),
+    module_name = "ArgumentParserToolInfo",
+)
+
+swift_library(
+    name = "ArgumentParser",
+    srcs = glob(["Sources/ArgumentParser/**/*.swift"]),
+    module_name = "ArgumentParser",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ArgumentParserToolInfo",
+    ],
+)

--- a/infra/patches/build_event_stream_java_proto.patch
+++ b/infra/patches/build_event_stream_java_proto.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
+index 313dccb..ad4e06d 100644
+--- src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
++++ src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
+@@ -25,6 +25,7 @@ java_proto_library(
+ proto_library(
+     name = "build_event_stream_proto",
+     srcs = ["build_event_stream.proto"],
++    visibility = ["//visibility:public"],
+     deps = [
+         "//src/main/protobuf:command_line_proto",
+         "//src/main/protobuf:failure_details_proto",

--- a/infra/patches/publish_build_event_proto.patch
+++ b/infra/patches/publish_build_event_proto.patch
@@ -1,0 +1,42 @@
+diff --git a/google/devtools/build/v1/BUILD.bazel b/google/devtools/build/v1/BUILD.bazel
+index 3e7c79d..075509e 100644
+--- google/devtools/build/v1/BUILD.bazel
++++ google/devtools/build/v1/BUILD.bazel
+@@ -48,6 +48,37 @@ load(
+ # This is an API workspace, having public visibility by default makes perfect sense.
+ package(default_visibility = ["//visibility:public"])
+
++proto_library(
++    name = "build_events_proto",
++    srcs = [
++        "build_events.proto",
++        "build_status.proto",
++    ],
++    deps = [
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:timestamp_proto",
++        "@com_google_protobuf//:wrappers_proto",
++    ],
++)
++
++proto_library(
++    name = "publish_build_event_proto",
++    srcs = [
++        "publish_build_event.proto",
++    ],
++    deps = [
++        ":build_events_proto",
++        "//google/api:annotations_proto",
++        "//google/api:client_proto",
++        "//google/api:field_behavior_proto",
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:duration_proto",
++        "@com_google_protobuf//:empty_proto",
++        "@com_google_protobuf//:timestamp_proto",
++        "@com_google_protobuf//:wrappers_proto",
++    ],
++)
++
+ proto_library(
+     name = "build_proto",
+     srcs = [

--- a/src/bep/BEPCommands/BUILD
+++ b/src/bep/BEPCommands/BUILD
@@ -1,0 +1,24 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "BEPCommands",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "BEPCommands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/bep/BEPCore",
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+    ],
+)
+
+swift_binary(
+    name = "bep",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":BEPCommands",
+    ],
+)

--- a/src/bep/BEPCommands/Sources/ParseCommand.swift
+++ b/src/bep/BEPCommands/Sources/ParseCommand.swift
@@ -1,0 +1,32 @@
+import ArgumentParser
+import BEPCore
+
+internal struct ParseCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "parse",
+        abstract: "A tool for parsing Bazel Build Event Protocol binary files.")
+
+    internal func run() throws {
+        print("ParseCommand")
+        let bepPath: String = "/Users/connorwybranowski/Downloads/ExampleTests_flaky_bep"
+        let parser: BEPParserImp = .init()
+        let flakyTestTargetMap: FlakyTestTargetMapImp = .init()
+        let flakyTargets: [FlakyTestTarget] = flakyTestTargetMap.map(
+            events: try parser.readEvents(bepPath: bepPath))
+        print("Found \(flakyTargets.count) flaky test targets:")
+        flakyTargets.forEach {
+            print("""
+            - label: \($0.label)
+              runsPerTest: \($0.runsPerTest)
+              totalRunCount: \($0.totalRunCount)
+              passedCount: \($0.passedCount)
+              failedCount: \($0.failedCount)
+              wallTimeDurationMillis: \($0.wallTimeDurationMillis)
+              systemTimeDurationMillis: \($0.systemTimeDurationMillis)
+              failedRunArtifactPaths:
+            \($0.failedRunArtifactPaths.map { "\t- \($0)" }.joined(separator: "\n"))
+            """)
+        }
+    }
+}

--- a/src/bep/BEPCommands/Sources/RootCommand.swift
+++ b/src/bep/BEPCommands/Sources/RootCommand.swift
@@ -1,0 +1,9 @@
+import ArgumentParser
+
+@main
+internal struct RootCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        abstract: "A tool for Bazel Build Event Protocol utilities.",
+        subcommands: [ParseCommand.self])
+}

--- a/src/bep/BEPCore/BUILD
+++ b/src/bep/BEPCore/BUILD
@@ -1,0 +1,24 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+    "swift_proto_library",
+)
+
+# [CW] 2/17/23 - https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+swift_proto_library(
+    name = "BEP_Protos",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_bazelbuild_bazel//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_proto",
+    ],
+)
+
+swift_library(
+    name = "BEPCore",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "BEPCore",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":BEP_Protos",
+    ],
+)

--- a/src/bep/BEPCore/Sources/BEPParser.swift
+++ b/src/bep/BEPCore/Sources/BEPParser.swift
@@ -1,0 +1,71 @@
+import Foundation
+import src_main_java_com_google_devtools_build_lib_buildeventstream_proto_build_event_stream_proto
+import SwiftProtobuf
+
+public protocol BEPParser {
+
+    func readEvents(bepPath: String) throws -> [BuildEventStream_BuildEvent]
+}
+
+public final class BEPParserImp: BEPParser {
+
+    enum Error: Swift.Error, CustomStringConvertible {
+        case missingBEPFile(path: String)
+        case bepParsingFailed(errors: [Swift.Error])
+
+        var description: String {
+            switch self {
+            case let .missingBEPFile(path: path):
+                return "Missing BEP file at path: \(path)"
+            case let .bepParsingFailed(errors: errors):
+                let errorString: String = errors.map { "- \($0)" }.joined(separator: "\n")
+                return """
+                BEP parsing failed with the following errors:
+                \(errorString)
+                """
+            }
+        }
+    }
+
+    public init() {}
+
+    // [CW] 2/18/23 - Adapted from:
+    // https://github.com/target/XCBBuildServiceProxy/blob/99392b04696f710be47b2c6297ea362c0a33d30c/Examples/BazelXCBBuildService/Sources/BazelBuildProcess.swift#L81
+    public func readEvents(bepPath: String) throws -> [BuildEventStream_BuildEvent] {
+        guard let bepFileHandle: FileHandle = .init(forReadingAtPath: bepPath) else {
+            throw Error.missingBEPFile(path: bepPath)
+        }
+        let semaphore: DispatchSemaphore = .init(value: 0)
+        var buildEvents: [BuildEventStream_BuildEvent] = []
+        var errors: [Swift.Error] = []
+        bepFileHandle.readabilityHandler = { fileHandle in
+            let data: Data = fileHandle.availableData
+            guard !data.isEmpty else {
+                return
+            }
+            let input: InputStream = .init(data: data)
+            input.open()
+            while input.hasBytesAvailable {
+                do {
+                    let event: BuildEventStream_BuildEvent = try BinaryDelimited.parse(
+                        messageType: BuildEventStream_BuildEvent.self,
+                        from: input)
+                    buildEvents.append(event)
+                    if event.lastMessage {
+                        fileHandle.closeFile()
+                        fileHandle.readabilityHandler = nil
+                        semaphore.signal()
+                    }
+                } catch {
+                    errors.append(error)
+                    return
+                }
+            }
+        }
+        _ = semaphore.wait(timeout: .now() + 30)
+        guard errors.isEmpty else {
+            throw Error.bepParsingFailed(errors: errors)
+        }
+        return buildEvents
+    }
+}

--- a/src/bep/BEPCore/Sources/Maps/FlakyTestTargetMap.swift
+++ b/src/bep/BEPCore/Sources/Maps/FlakyTestTargetMap.swift
@@ -1,0 +1,60 @@
+import src_main_java_com_google_devtools_build_lib_buildeventstream_proto_build_event_stream_proto
+
+public protocol FlakyTestTargetMap {
+
+    func map(events: [BuildEventStream_BuildEvent]) -> [FlakyTestTarget]
+}
+
+public final class FlakyTestTargetMapImp: FlakyTestTargetMap {
+
+    public init() {}
+
+    public func map(events: [BuildEventStream_BuildEvent]) -> [FlakyTestTarget] {
+        let failedArtifactPathsByTarget: [String: [String]] = makeFailedArtifactPathsByTarget(events: events)
+        return events
+            .filter {
+                $0.testSummary.overallStatus == .flaky
+            }
+            .map {
+                makeFlakyTestTarget(
+                    event: $0,
+                    failedArtifactPathsByTarget: failedArtifactPathsByTarget)
+            }
+    }
+
+    private func makeFlakyTestTarget(
+        event: BuildEventStream_BuildEvent,
+        failedArtifactPathsByTarget: [String: [String]]
+    ) -> FlakyTestTarget {
+        .init(
+            label: event.id.testSummary.label,
+            runsPerTest: Int(event.testSummary.runCount),
+            totalRunCount: Int(event.testSummary.totalRunCount),
+            passedCount: event.testSummary.passed.count,
+            failedCount: event.testSummary.failed.count,
+            wallTimeDurationMillis: event.testSummary.lastStopTimeMillis - event.testSummary.firstStartTimeMillis,
+            systemTimeDurationMillis: event.testSummary.totalRunDurationMillis,
+            failedRunArtifactPaths: failedArtifactPathsByTarget[event.id.testSummary.label] ?? [])
+    }
+
+    private func makeFailedArtifactPathsByTarget(
+        events: [BuildEventStream_BuildEvent]
+    ) -> [String: [String]] {
+        events.filter {
+            $0.testResult.status == .failed
+        }.reduce(into: [String: [String]]()) { partialResult, value in
+            let targetLabel: String = value.id.testResult.label
+            var existing: [String] = partialResult[targetLabel] ?? []
+            existing.append(contentsOf: value.testResult.testActionOutput.map(\.uri).map(parseURI))
+            partialResult[targetLabel] = existing
+        }
+    }
+
+    private func parseURI(_ uri: String) -> String {
+        let prefix: String = "file://"
+        guard uri.hasPrefix(prefix) else {
+            return uri
+        }
+        return String(uri.dropFirst(prefix.count))
+    }
+}

--- a/src/bep/BEPCore/Sources/Models/FlakyTestTarget.swift
+++ b/src/bep/BEPCore/Sources/Models/FlakyTestTarget.swift
@@ -1,0 +1,10 @@
+public struct FlakyTestTarget {
+    public let label: String
+    public let runsPerTest: Int
+    public let totalRunCount: Int
+    public let passedCount: Int
+    public let failedCount: Int
+    public let wallTimeDurationMillis: Int64
+    public let systemTimeDurationMillis: Int64
+    public let failedRunArtifactPaths: [String]
+}

--- a/src/bep/BESServer/BUILD
+++ b/src/bep/BESServer/BUILD
@@ -1,0 +1,54 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_grpc_library",
+    "swift_library",
+    "swift_proto_library",
+)
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "xcodeproj",
+)
+
+swift_proto_library(
+    name = "publish_build_event_proto_swift",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_googleapis//google/devtools/build/v1:publish_build_event_proto",
+    ],
+)
+
+swift_grpc_library(
+    name = "publish_build_event_server_services_swift",
+    srcs = ["@com_google_googleapis//google/devtools/build/v1:publish_build_event_proto"],
+    flavor = "server",
+    deps = [":publish_build_event_proto_swift"],
+)
+
+swift_library(
+    name = "BESServer",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "BESServer",
+    deps = [
+        ":publish_build_event_server_services_swift",
+        "//src/bep/BEPCore",
+        "//src/bep/BEPCore:BEP_Protos",
+    ],
+)
+
+swift_binary(
+    name = "publish_build_event_server",
+    srcs = ["Server/main.swift"],
+    deps = [
+        ":BESServer",
+    ],
+)
+
+xcodeproj(
+    name = "project",
+    project_name = "project",
+    tags = ["manual"],
+    top_level_targets = [
+        ":publish_build_event_server",
+    ],
+)

--- a/src/bep/BESServer/Server/main.swift
+++ b/src/bep/BESServer/Server/main.swift
@@ -1,0 +1,3 @@
+import BESServer
+
+try await PublishBuildEventServer.startServer()

--- a/src/bep/BESServer/Sources/Interceptors/BuildEventServerInterceptor.swift
+++ b/src/bep/BESServer/Sources/Interceptors/BuildEventServerInterceptor.swift
@@ -1,0 +1,66 @@
+import Foundation
+import GRPC
+import google_devtools_build_v1_publish_build_event_proto
+import src_main_java_com_google_devtools_build_lib_buildeventstream_proto_build_event_stream_proto
+import SwiftProtobuf
+
+enum BuildEventsKey: UserInfoKey {
+    typealias Value = [BuildEventStream_BuildEvent]
+}
+
+// [CW] 2/20/23 - Based on:
+// https://github.com/grpc/grpc-swift/blob/main/docs/interceptors-tutorial.md
+class BuildEventServerInterceptor: ServerInterceptor
+<
+    Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest,
+    Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse
+> {
+
+    private var buildEvents: [BuildEventStream_BuildEvent] = []
+
+    override func receive(
+        _ part: GRPCServerRequestPart<Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest>,
+        context: ServerInterceptorContext<Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest, Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse>
+    ) {
+        switch part {
+        case .metadata(_):
+            break
+        case let .message(response):
+            appendBuildEventIfNeeded(bazelEvent: response.orderedBuildEvent.event.bazelEvent)
+        case .end:
+            context.userInfo[BuildEventsKey.self] = buildEvents
+            writeBuildEventsLog()
+        }
+        // Forward the response part to the next interceptor.
+        context.receive(part)
+    }
+
+    private func appendBuildEventIfNeeded(bazelEvent: Google_Protobuf_Any) {
+        do {
+            let buildEvent: BuildEventStream_BuildEvent = try BuildEventStream_BuildEvent(
+                unpackingAny: bazelEvent)
+            buildEvents.append(buildEvent)
+        } catch {
+            print("❌ Failed to cast to BuildEventStream_BuildEvent: \(bazelEvent.typeURL)")
+        }
+    }
+
+    private func writeBuildEventsLog() {
+        do {
+            let paths: [URL] = FileManager.default.urls(
+                for: .downloadsDirectory,
+                in: .userDomainMask)
+            let artifactURL: URL = paths[0]
+                .appending(path: "bes-logs")
+                .appending(path: "\(UUID().uuidString)__build_events.log")
+            let logOutput: String = buildEvents.map { "\($0)" }.joined(separator: "\n\n")
+            try logOutput.write(
+                to: artifactURL,
+                atomically: true,
+                encoding: .utf8)
+            print("✅ Wrote \(buildEvents.count) build events to path: \(artifactURL.absoluteString)")
+        } catch {
+            print("❌ Error writing build events log: \(error)")
+        }
+    }
+}

--- a/src/bep/BESServer/Sources/Interceptors/FlakyTestTargetServerInterceptor.swift
+++ b/src/bep/BESServer/Sources/Interceptors/FlakyTestTargetServerInterceptor.swift
@@ -1,0 +1,40 @@
+import BEPCore
+import GRPC
+import google_devtools_build_v1_publish_build_event_proto
+import src_main_java_com_google_devtools_build_lib_buildeventstream_proto_build_event_stream_proto
+
+class FlakyTestTargetServerInterceptor: ServerInterceptor
+<
+    Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest,
+    Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse
+> {
+
+    override func receive(
+        _ part: GRPCServerRequestPart<Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest>,
+        context: ServerInterceptorContext<Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest, Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse>
+    ) {
+        if let buildEvents: [BuildEventStream_BuildEvent] = context.userInfo[BuildEventsKey.self], !buildEvents.isEmpty {
+            detectFlakyTests(buildEvents: buildEvents)
+        }
+        context.receive(part)
+    }
+
+    private func detectFlakyTests(buildEvents: [BuildEventStream_BuildEvent]) {
+       let flakyTestTargetMap: FlakyTestTargetMapImp = .init()
+       let flakyTargets: [FlakyTestTarget] = flakyTestTargetMap.map(events: buildEvents)
+       print("✅ Found \(flakyTargets.count) flaky test targets:")
+       flakyTargets.forEach {
+           print("""
+           - label: \($0.label)
+             runsPerTest: \($0.runsPerTest)
+             totalRunCount: \($0.totalRunCount)
+             passedCount: \($0.passedCount)
+             failedCount: \($0.failedCount)
+             wallTimeDurationMillis: \($0.wallTimeDurationMillis)
+             systemTimeDurationMillis: \($0.systemTimeDurationMillis)
+             failedRunArtifactPaths:
+           \($0.failedRunArtifactPaths.map { "\t- \($0)" }.joined(separator: "\n"))
+           """)
+       }
+   }
+}

--- a/src/bep/BESServer/Sources/PublishBuildEventProvider.swift
+++ b/src/bep/BESServer/Sources/PublishBuildEventProvider.swift
@@ -1,0 +1,37 @@
+import GRPC
+import google_devtools_build_v1_publish_build_event_proto
+import NIO
+import src_bep_BESServer_publish_build_event_server_services_swift
+import SwiftProtobuf
+
+class PublishBuildEventProviderImp: Google_Devtools_Build_V1_PublishBuildEventProvider {
+
+    private var sequenceNumber: Int64 = 1
+    var interceptors: Google_Devtools_Build_V1_PublishBuildEventServerInterceptorFactoryProtocol? = PublishBuildEventServerInterceptorFactory()
+
+    func publishLifecycleEvent(
+        request: Google_Devtools_Build_V1_PublishLifecycleEventRequest,
+        context: StatusOnlyCallContext
+    ) -> EventLoopFuture<SwiftProtobuf.Google_Protobuf_Empty> {
+        context.eventLoop.makeSucceededFuture(.init())
+    }
+
+    func publishBuildToolEventStream(
+        context: StreamingResponseCallContext<Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse>
+    ) -> EventLoopFuture<(StreamEvent<Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest>) -> Void> {
+        context.eventLoop.makeSucceededFuture({ [weak self] event in
+            guard let self = self else { return }
+            switch event {
+            case .message(_):
+                let response: Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse = .with {
+                    $0.sequenceNumber = self.sequenceNumber
+                }
+                self.sequenceNumber += 1
+                context.sendResponse(response, promise: nil)
+            case .end:
+                self.sequenceNumber = 1
+                context.statusPromise.succeed(.ok)
+            }
+        })
+    }
+}

--- a/src/bep/BESServer/Sources/PublishBuildEventServer.swift
+++ b/src/bep/BESServer/Sources/PublishBuildEventServer.swift
@@ -1,0 +1,16 @@
+import GRPC
+import NIO
+
+public enum PublishBuildEventServer {
+
+    public static func startServer() async throws {
+        // [CW] 2/20/23 - Based on:
+        // https://github.com/grpc/grpc-swift/blob/main/Sources/Examples/Echo/Runtime/Echo.swift#L120
+        let builder: Server.Builder = Server.insecure(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+        let server = try await builder.withServiceProviders([PublishBuildEventProviderImp()])
+            .bind(host: "localhost", port: 9000)
+            .get()
+        print("Started BES server: \(server.channel.localAddress!)")
+        try await server.onClose.get()
+    }
+}

--- a/src/bep/BESServer/Sources/PublishBuildEventServerInterceptorFactory.swift
+++ b/src/bep/BESServer/Sources/PublishBuildEventServerInterceptorFactory.swift
@@ -1,0 +1,17 @@
+import GRPC
+import google_devtools_build_v1_publish_build_event_proto
+import src_bep_BESServer_publish_build_event_server_services_swift
+import SwiftProtobuf
+
+class PublishBuildEventServerInterceptorFactory: Google_Devtools_Build_V1_PublishBuildEventServerInterceptorFactoryProtocol {
+    func makePublishLifecycleEventInterceptors() -> [GRPC.ServerInterceptor<google_devtools_build_v1_publish_build_event_proto.Google_Devtools_Build_V1_PublishLifecycleEventRequest, SwiftProtobuf.Google_Protobuf_Empty>] {
+        []
+    }
+
+    func makePublishBuildToolEventStreamInterceptors() -> [GRPC.ServerInterceptor<google_devtools_build_v1_publish_build_event_proto.Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest, google_devtools_build_v1_publish_build_event_proto.Google_Devtools_Build_V1_PublishBuildToolEventStreamResponse>] {
+        [
+            BuildEventServerInterceptor(),
+            FlakyTestTargetServerInterceptor()
+        ]
+    }
+}

--- a/src/bep/BUILD
+++ b/src/bep/BUILD
@@ -1,0 +1,14 @@
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "xcodeproj",
+)
+
+xcodeproj(
+    name = "project",
+    project_name = "project",
+    tags = ["manual"],
+    top_level_targets = [
+        "//src/bep/BEPCommands:bep",
+        "//src/bep/BESServer:bes_server",
+    ],
+)

--- a/src/bep/Fixtures/BUILD
+++ b/src/bep/Fixtures/BUILD
@@ -1,0 +1,23 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+load(
+    "@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_unit_test",
+)
+
+swift_library(
+    name = "ExampleTestsLib",
+    testonly = True,
+    srcs = ["Sources/ExampleTests.swift"],
+)
+
+ios_unit_test(
+    name = "ExampleTests",
+    minimum_os_version = "16.0",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    deps = [
+        ":ExampleTestsLib",
+    ],
+)

--- a/src/bep/Fixtures/Sources/ExampleTests.swift
+++ b/src/bep/Fixtures/Sources/ExampleTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+class ExampleTests: XCTestCase {
+
+    func testFlaky() throws {
+        if try XCTUnwrap([false, true].randomElement()) == true {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Flaky")
+        }
+    }
+}

--- a/src/bep/README.md
+++ b/src/bep/README.md
@@ -1,0 +1,8 @@
+# Build Event Protocol Exploration
+
+- [Build Event Protocol](https://bazel.build/remote/bep) Parsing via Protocol Buffers
+    - [BEPParser](BEPCore/Sources/BEPParser.swift)
+- [Build Event Service](https://bazel.build/remote/bep#build-event-service) via [built-in Bazel gRPC service](https://github.com/googleapis/googleapis/blob/master/google/devtools/build/v1/publish_build_event.proto)
+    - [BESServer](BESServer/Sources/PublishBuildEventServer.swift)
+    - [BuildEventServerInterceptor](BESServer/Sources/Interceptors/BuildEventServerInterceptor.swift): Capture `BuildEventStream_BuildEvent` from `Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest` and store in `UserInfo` for use in future interceptors.
+    - [FlakyTestTargetServerInterceptor](BESServer/Sources/Interceptors/FlakyTestTargetServerInterceptor.swift): Consume `UserInfo`-stored `BuildEventStream_BuildEvent` to detect flaky tests in streamed builds.


### PR DESCRIPTION
### Description

Add several pieces of key [BEP](https://bazel.build/remote/bep) / [BES](https://bazel.build/remote/bep#build-event-service) infrastructure to support current and future explorations, including:
- `BEPParser`
- BES Server types (e.g. gRPC types like `PublishBuildEventProviderImp`, interceptors, etc.)

### Changelog

- ADDED:
    - Dependencies
        - `com_github_bazelbuild_rules_proto`
        - `com_github_bazelbuild_bazel`
        - `com_github_apple_swift_argument_parser`
        - `build_bazel_rules_apple` (for `ios_xctestrun_ordered_runner`)
        - `com_google_googleapis`
    - Targets
        - `BEPCore`
        - `BESServer`
        - `publish_build_event_server`