### PR TITLE
XCResult Exploration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,5 +4,7 @@ test:bep_fixture --runs_per_test=10
 test:bep_fixture --runs_per_test_detects_flakes=true
 test:bep_fixture -t-
 test:bep_fixture --test_env=CREATE_XCRESULT_BUNDLE=1
+test:bep_fixture --zip_undeclared_test_outputs=false
+test:bep_fixture --build_event_binary_file=/tmp/bazel/bep
 build:bes_server --bes_backend=grpc://localhost:9000
 build:bes_server --bes_upload_mode=fully_async

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,9 @@ bes_server:
 build_bes: target ?= placeholder
 build_bes:
 	bazelisk build $(target) --config=bes_server
+
+.PHONY xcresultparser_demo:
+xcresultparser_demo:
+	bazelisk test //src/bep/Fixtures:ExampleTests --config=bep_fixture && \
+	XCRESULT_PATH=$$(bazelisk run //src/bep/BEPCommands:bep -- extract-xcresult --bep-path=/tmp/bazel/bep) && \
+	bazelisk run //src/xcresult/XCResultParser:xcresultparser -- --xcresult-path=$$XCRESULT_PATH

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ A project exploring the use of Bazel and Swift across various use-cases.
 ## Explorations
 
 - [Build Event Protocol Parsing via Protocol Buffers](src/bep)
+- [XCResult Parsing](src/xcresult)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,3 +106,10 @@ http_archive(
     strip_prefix = "swift-argument-parser-1.2.2",
     url = "https://github.com/apple/swift-argument-parser/archive/refs/tags/1.2.2.tar.gz",
 )
+
+http_archive(
+    name = "com_github_kylef_pathkit",
+    build_file = "pathkit/BUILD",
+    strip_prefix = "pathkit-1.0.1",
+    url = "https://github.com/kylef/PathKit/archive/refs/tags/1.0.1.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,3 +113,11 @@ http_archive(
     strip_prefix = "pathkit-1.0.1",
     url = "https://github.com/kylef/PathKit/archive/refs/tags/1.0.1.tar.gz",
 )
+
+http_archive(
+    name = "com_github_stencilproject_stencil",
+    build_file = "stencil/BUILD",
+    sha256 = "7e1d7b72cd07af0b31d8db6671540c357005d18f30c077f2dff0f84030995010",
+    strip_prefix = "Stencil-0.15.1",
+    url = "https://github.com/stencilproject/Stencil/archive/refs/tags/0.15.1.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,3 +121,10 @@ http_archive(
     strip_prefix = "Stencil-0.15.1",
     url = "https://github.com/stencilproject/Stencil/archive/refs/tags/0.15.1.tar.gz",
 )
+
+http_archive(
+    name = "com_github_jpsim_yams",
+    sha256 = "16f0d7e4aecdd241c715ba7fa9a669b0655b076c424e05c6b6a7ea2267f9b3dd",
+    strip_prefix = "Yams-5.0.5",
+    url = "https://github.com/jpsim/Yams/archive/refs/tags/5.0.5.tar.gz",
+)

--- a/external/pathkit/BUILD
+++ b/external/pathkit/BUILD
@@ -1,0 +1,11 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "PathKit",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "PathKit",
+    visibility = ["//visibility:public"],
+)

--- a/external/stencil/BUILD
+++ b/external/stencil/BUILD
@@ -1,0 +1,14 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "Stencil",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "Stencil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_kylef_pathkit//:PathKit",
+    ],
+)

--- a/src/bep/BEPCommands/BUILD
+++ b/src/bep/BEPCommands/BUILD
@@ -12,6 +12,7 @@ swift_library(
     deps = [
         "//src/bep/BEPCore",
         "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_kylef_pathkit//:PathKit",
     ],
 )
 

--- a/src/bep/BEPCommands/Sources/ExtractXCResultCommand.swift
+++ b/src/bep/BEPCommands/Sources/ExtractXCResultCommand.swift
@@ -1,0 +1,65 @@
+import ArgumentParser
+import BEPCore
+import PathKit
+import src_main_java_com_google_devtools_build_lib_buildeventstream_proto_build_event_stream_proto
+
+internal struct ExtractXCResultCommand: ParsableCommand {
+
+    internal enum Error: Swift.Error, CustomStringConvertible {
+        case missingTestOutputs
+        case missingXCResults
+
+        internal var description: String {
+            switch self {
+                case .missingTestOutputs:
+                    return "Missing 'test.outputs' directory in BEP file"
+                case .missingXCResults:
+                    return "Missing 'tests.xcresult' files in BEP file"
+            }
+        }
+    }
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "extract-xcresult",
+        abstract: "A tool for extracting paths to XCResult files from a Bazel BEP binary file. If multiple XCResult files are found, only the first is returned.")
+
+    @Option(name: .long, help: "Path to Bazel BEP file.")
+    internal var bepPath: String
+
+    internal func run() throws {
+        let parser: BEPParserImp = .init()
+        let events: [BuildEventStream_BuildEvent] = try parser.readEvents(bepPath: bepPath)
+        let testOutputsPaths: [BuildEventStream_File] = events
+            .flatMap {
+                $0.testResult.testActionOutput
+            }
+            .filter {
+                $0.name == "test.outputs"
+            }
+        guard !testOutputsPaths.isEmpty else {
+            throw Error.missingTestOutputs
+        }
+        let xcresultPaths: [Path] = try testOutputsPaths
+            .map {
+                parseURI(uri: $0.uri)
+            }
+            .flatMap { path in
+                try path.children().filter {
+                    $0.lastComponent == "tests.xcresult"
+                }
+            }
+        guard !xcresultPaths.isEmpty else {
+            throw Error.missingXCResults
+        }
+        print(xcresultPaths[0].string)
+    }
+
+    private func parseURI(uri: String) -> Path {
+        let prefix: String = "file://"
+        if uri.hasPrefix(prefix) {
+            return Path(String(uri.dropFirst(prefix.count)))
+        } else {
+            return Path(uri)
+        }
+    }
+}

--- a/src/bep/BEPCommands/Sources/RootCommand.swift
+++ b/src/bep/BEPCommands/Sources/RootCommand.swift
@@ -5,5 +5,8 @@ internal struct RootCommand: ParsableCommand {
 
     internal static let configuration: CommandConfiguration = .init(
         abstract: "A tool for Bazel Build Event Protocol utilities.",
-        subcommands: [ParseCommand.self])
+        subcommands: [
+            ParseCommand.self,
+            ExtractXCResultCommand.self
+        ])
 }

--- a/src/xcresult/README.md
+++ b/src/xcresult/README.md
@@ -1,0 +1,13 @@
+# XCResult Exploration
+
+- [WIP] [Generated `.xcresult` parsing models](XCResultCommands/Sources/GenerateCommand.swift)
+    - [x] Generate models from `xcrun xcresulttool formatDescription` & vend to consumers via `XCResultTypes_Generated` `swift_library`.
+    - [x] Consume `XCResultTypes_Generated` to [decode partial `.xcresult` contents](XCResultParser/Sources/RootCommand.swift).
+    - [x] Add [`TypeOverrides`](XCResultCommands/Sources/Models/TypeOverrides.swift) to override `xcrun xcresulttool formationDescription get` types, allowing specific subclasses to be used over the lowest-level base classes.
+    - [ ] Resolve heterogeneous decoding of types (e.g. `ActionTestSummaryGroup` > `ActionTestMetadata`) -- currently the superclass is used (e.g. `ActionTestSummaryIdentifiableObject`)
+        - Strategy 1: Custom switch-based decoders for types that utilize super/subclassing
+        - Strategy 2: Create a middleware type system to convert XCResult into, to make the API nicer to work with (and more like a standard decoding setup) (e.g. `XCResult as JSON > Middleware Type > XCResult as Swift`)
+            - Heterogeneous arrays in the `XCResult as JSON` layer could be flattened into homogeneous arrays in the `Middleware Type`, then a specific subclass can easily be used for decoding to transition into the `XCResult as Swift` layer
+                - e.g. `tests: ActionTestSummaryIdentifiableObject` could be flattened to:
+                    - `action_test_summary_groups: ActionTestSummaryGroup` (with a reference to the parent `ActionTestSummaryGroup` / `ActionTestableSummary`)
+                    - `action_test_metadatas: ActionTestMetadata` (with a reference to the parent `ActionTestSummaryGroup`)

--- a/src/xcresult/XCResultCommands/BUILD
+++ b/src/xcresult/XCResultCommands/BUILD
@@ -1,0 +1,51 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "XCResultCommands",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "XCResultCommands",
+    deps = [
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_jpsim_yams//:Yams",
+        "@com_github_kylef_pathkit//:PathKit",
+        "@com_github_stencilproject_stencil//:Stencil",
+    ],
+)
+
+swift_binary(
+    name = "xcresult",
+    deps = [
+        ":XCResultCommands",
+    ],
+)
+
+genrule(
+    name = "xcrun_xcresulttool_format_description",
+    outs = ["format_description.json"],
+    cmd = "xcrun xcresulttool formatDescription get --format=json --version=3 > \"$@\"",
+)
+
+genrule(
+    name = "generate_xcresult_types",
+    srcs = [
+        "format_description.json",
+        "Resources/xcrun_xcresulttool_formationDescription_get__overrides_v3.yml",
+    ],
+    outs = ["GeneratedXCResultTypes.swift"],
+    cmd = "./$(location xcresult) generate --format-description-json-path=$(location format_description.json) --type-overrides-path=$(location Resources/xcrun_xcresulttool_formationDescription_get__overrides_v3.yml)  > \"$@\"",
+    tools = [":xcresult"],
+)
+
+swift_library(
+    name = "XCResultTypes_Generated",
+    srcs = [
+        "GeneratedXCResultTypes.swift",
+        "XCResultTypes_Generated/HandwrittenTypes.swift",
+    ],
+    module_name = "XCResultTypes_Generated",
+    visibility = ["//visibility:public"],
+)

--- a/src/xcresult/XCResultCommands/Resources/xcrun_xcresulttool_formationDescription_get__overrides_v3.yml
+++ b/src/xcresult/XCResultCommands/Resources/xcrun_xcresulttool_formationDescription_get__overrides_v3.yml
@@ -1,0 +1,6 @@
+overrides:
+  - type: ActionTestableSummary
+    properties:
+      - name: tests
+        generatedType: ActionTestSummaryIdentifiableObject
+        overrideType: ActionTestSummaryGroup

--- a/src/xcresult/XCResultCommands/Sources/Extensions/Encodable+Extension.swift
+++ b/src/xcresult/XCResultCommands/Sources/Extensions/Encodable+Extension.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Encodable {
+
+    // [CW] 2/25/23 - Adapted from: https://stackoverflow.com/a/52924356
+    func toDictionary() throws -> [String: Any] {
+        let data: Data = try JSONEncoder().encode(self)
+        let object: Any = try JSONSerialization.jsonObject(with: data)
+        guard let json = object as? [String: Any] else {
+            let context = DecodingError.Context(
+                codingPath: [],
+                debugDescription: "Deserialized object is not a dictionary")
+            throw DecodingError.typeMismatch(type(of: object), context)
+        }
+        return json
+    }
+}

--- a/src/xcresult/XCResultCommands/Sources/GenerateCommand.swift
+++ b/src/xcresult/XCResultCommands/Sources/GenerateCommand.swift
@@ -1,0 +1,70 @@
+import ArgumentParser
+import Foundation
+import PathKit
+import Stencil
+import Yams
+
+internal struct GenerateCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "generate",
+        abstract: "A tool for generating XCResult parsing types.")
+
+    @Option(name: .long, help: "Path to 'xcrun xcresulttool formatDescription' JSON file.")
+    internal var formatDescriptionJSONPath: String
+
+    @Option(name: .long, help: "Path to YAML file containing overrides for generated types.")
+    internal var typeOverridesPath: String?
+
+    internal func run() throws {
+        let fileData: Data = try Path(formatDescriptionJSONPath).read()
+        let formatDescription: FormatDescription = try JSONDecoder().decode(FormatDescription.self, from: fileData)
+        let typeOverrides: TypeOverrides = try makeTypeOverrides()
+        let renderModel: RenderFormatDescription = .init(
+            formatDescription: formatDescription,
+            typeOverrides: typeOverrides)
+        let rendered: String = try render(context: renderModel.toDictionary())
+        print(rendered)
+    }
+
+    private func makeTypeOverrides() throws -> TypeOverrides {
+        guard let typeOverridesPath: String = typeOverridesPath else {
+            return TypeOverrides(overrides: [])
+        }
+        let fileData: Data = try Path(typeOverridesPath).read()
+        return try YAMLDecoder().decode(TypeOverrides.self, from: fileData)
+    }
+
+    private func render(context: [String: Any]) throws -> String {
+        let template: String = """
+            // GENERATED FILE - DO NOT EDIT
+            // name = {{ name }}
+            // version = {{ version.major }}.{{ version.minor }}
+
+            import Foundation
+
+            extension {{ typeExtension }} {
+                {% for type in types %}
+
+                {% if type.isBaseClass %}open {% else %}public {% endif %}class {{ type.type.name }}: {% if type.type.supertype %}{{ type.type.supertype }}{% else %}Codable{% endif %} {
+                    {% for property in type.properties %}
+                    public let {{ property.propertyName }}: {{ property.finalType }}{% endfor %}
+                    {% if type.properties %}
+                    enum CodingKeys: Swift.String, CodingKey {
+                        {% for property in type.properties %}
+                        case {{ property.propertyName }}{% endfor %}
+                    }
+
+                    required public init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self){% for property in type.properties %}
+                        {{ property.propertyName }} = try container.decode{% if property.isOptional %}IfPresent{% endif %}({{ property.finalTypeNonOptional }}.self, forKey: .{{ property.propertyName }}){% endfor %}{% if type.type.supertype %}
+                        try super.init(from: decoder){% endif %}
+                    }{% endif %}
+                }{% endfor %}
+            }
+            """
+        return try Environment().renderTemplate(
+            string: template,
+            context :context)
+    }
+}

--- a/src/xcresult/XCResultCommands/Sources/Models/FormatDescription.swift
+++ b/src/xcresult/XCResultCommands/Sources/Models/FormatDescription.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+internal struct FormatDescription: Codable {
+
+    internal struct Version: Codable {
+        let major: Int
+        let minor: Int
+    }
+
+    internal struct FormatType: Codable {
+
+        internal struct `Type`: Codable {
+            let name: String
+            let supertype: String?
+        }
+
+        internal struct Property: Codable {
+            let isOptional: Bool
+            let isInternal: Bool
+            let wrappedType: String?
+            let name: String
+            let type: String
+        }
+
+        internal enum Kind: String, Codable {
+            case object, value, array
+        }
+
+        let type: Type
+        let kind: Kind
+        let properties: [Property]?
+    }
+
+    let name: String
+    let version: Version
+    let types: [FormatType]
+}

--- a/src/xcresult/XCResultCommands/Sources/Models/RenderFormatDescription.swift
+++ b/src/xcresult/XCResultCommands/Sources/Models/RenderFormatDescription.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// [CW] 2/25/23 - Enhanced model of the Codable version ('FormatDescription'), containing extra fields that
+// reduce the complexity of the stencil render template.
+internal struct RenderFormatDescription: Codable {
+
+    internal struct RenderFormatType: Codable {
+
+        internal struct RenderProperty: Codable {
+
+            let propertyName: String
+            let isOptional: Bool
+            let finalType: String
+            let finalTypeNonOptional: String
+
+            init(
+                property: FormatDescription.FormatType.Property,
+                optionalOverride: Bool,
+                typeExtension: String,
+                override: TypeOverrides.Override?
+            ) {
+                self.propertyName = property.name
+                let isOptional: Bool = property.isOptional || optionalOverride
+                self.isOptional = isOptional
+                let baseType: String = {
+                    let propertyType: String = property.wrappedType ?? property.type
+                    if let overrideType: String = override?.overrideType(
+                        propertyName: property.name,
+                        generatedType: propertyType
+                    ) {
+                        return overrideType
+                    } else {
+                        return propertyType
+                    }
+                }()
+                let nonPrefixedFinalType: String = {
+                    if let wrappedType: String = property.wrappedType {
+                        switch property.type {
+                            case "Array":
+                                return "Array<\(baseType)>"
+                            case "Optional":
+                                if !property.isOptional {
+                                    fatalError("Property type is 'Optional' but 'isOptional' is false: \(property.name)")
+                                }
+                                return baseType
+                            default:
+                                fatalError("Unexpected wrappedType: \(wrappedType)")
+                        }
+                    } else {
+                        return baseType
+                    }
+                }()
+                let wrappedNonPrefixedFinalType: String = {
+                    guard [
+                        "String",
+                        "Bool",
+                        "Double",
+                        "Int",
+                        "Date"
+                    ].contains(baseType) else {
+                        return nonPrefixedFinalType
+                    }
+                    return "ValueType<\(nonPrefixedFinalType)>"
+                }()
+                let possiblyOptionalNonPrefixedFinalType: String = {
+                    isOptional ? "\(wrappedNonPrefixedFinalType)?" : wrappedNonPrefixedFinalType
+                }()
+                self.finalType = "\(typeExtension).\(possiblyOptionalNonPrefixedFinalType)"
+                self.finalTypeNonOptional = (isOptional && self.finalType.hasSuffix("?"))
+                    ? String(self.finalType.dropLast())
+                    : self.finalType
+            }
+        }
+
+        let type: FormatDescription.FormatType.`Type`
+        let kind: FormatDescription.FormatType.Kind
+        let properties: [RenderProperty]?
+        let isBaseClass: Bool
+
+        init(
+            formatType: FormatDescription.FormatType,
+            isBaseClass: Bool,
+            optionalOverride: Bool,
+            typeExtension: String,
+            typeOverrides: TypeOverrides
+        ) {
+            self.type = formatType.type
+            self.kind = formatType.kind
+            self.properties = formatType.properties?.map {
+                RenderProperty(
+                    property: $0,
+                    optionalOverride: optionalOverride,
+                    typeExtension: typeExtension,
+                    override: typeOverrides.override(typeName: formatType.type.name))
+            }
+            self.isBaseClass = isBaseClass
+        }
+    }
+
+    let name: String
+    let version: FormatDescription.Version
+    let types: [RenderFormatType]
+    let typeExtension: String
+
+    // [CW] 2/26/23 - 'optionalOverride' is used to treat properties that are declared non-optional (per the
+    // raw 'xcrun xcresulttool formatDescription get' output) as optional. This is required because in practice,
+    // some non-optional types may not exist in the XCResult file (e.g. 'ResultIssueSummaries.analyzerWarningSummaries').
+    //
+    // [CW] 2/26/23 - 'typeExtension' is used to inject the enum type that will contain all models (handwritten and
+    // generated). This enum will avoid polluting the global type namespace when a consumer imports the 'XCResultTypes_Generated'
+    // module, particularly for conflicting 'Swift.*' / 'Foundation.*' types.
+    init(
+        formatDescription: FormatDescription,
+        optionalOverride: Bool = true,
+        typeExtension: String = "XCResultTypes",
+        typeOverrides: TypeOverrides
+    ) {
+        self.name = formatDescription.name
+        self.version = formatDescription.version
+        let baseClasses: Set<String> = Set(formatDescription.types.map(\.type).compactMap(\.supertype))
+        self.types = formatDescription.types
+            .filter {
+                $0.kind == .object
+            }
+            .map {
+                RenderFormatType(
+                    formatType: $0,
+                    isBaseClass: baseClasses.contains($0.type.name),
+                    optionalOverride: optionalOverride,
+                    typeExtension: typeExtension,
+                    typeOverrides: typeOverrides)
+            }
+        self.typeExtension = typeExtension
+    }
+}

--- a/src/xcresult/XCResultCommands/Sources/Models/TypeOverrides.swift
+++ b/src/xcresult/XCResultCommands/Sources/Models/TypeOverrides.swift
@@ -1,0 +1,39 @@
+// [CW] 3/4/23 - Allows the output of 'xcrun xcresulttool formationDescription get' to be overridden. By replacing
+// types in 'formationDescription', a type other than the one provided by the tool can be used in code-generated models.
+// This is useful for types that are limited by their supertype, which would otherwise prevent them from decoding
+// to a more specific subclass.
+struct TypeOverrides: Codable {
+
+    struct Override: Codable {
+
+        struct PropertyOverride: Codable {
+            let name: String
+            let generatedType: String
+            let overrideType: String
+        }
+
+        let `type`: String
+        let properties: [PropertyOverride]
+
+        func propertyOverride(for propertyName: String) -> PropertyOverride? {
+            properties.first {
+                $0.name == propertyName
+            }
+        }
+
+        func overrideType(propertyName: String, generatedType: String) -> String? {
+            properties.first {
+                $0.name == propertyName
+                    && $0.generatedType == generatedType
+            }?.overrideType
+        }
+    }
+
+    let overrides: [Override]
+
+    func override(typeName: String) -> Override? {
+        overrides.first {
+            $0.`type` == typeName
+        }
+    }
+}

--- a/src/xcresult/XCResultCommands/Sources/RootCommand.swift
+++ b/src/xcresult/XCResultCommands/Sources/RootCommand.swift
@@ -1,0 +1,10 @@
+import ArgumentParser
+
+@main
+internal struct RootCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "xcresult",
+        abstract: "A tool for XCResult utilities.",
+        subcommands: [GenerateCommand.self])
+}

--- a/src/xcresult/XCResultCommands/XCResultTypes_Generated/HandwrittenTypes.swift
+++ b/src/xcresult/XCResultCommands/XCResultTypes_Generated/HandwrittenTypes.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+public enum XCResultTypes {
+
+    public struct NestedValue: Codable {
+
+        private enum CodingKeys: Swift.String, CodingKey {
+            case name = "_name"
+        }
+
+        public let name: String
+    }
+
+    public struct ValueType<T: Codable>: Codable {
+
+        private enum CodingKeys: Swift.String, CodingKey {
+            case type = "_type"
+            case value = "_value"
+        }
+
+        public let type: NestedValue
+        public let value: T
+
+        private static func castIfPossible<T, U>(value: () -> T?) throws -> U {
+            guard
+                let value: T = value(),
+                let castedValue: U = value as? U
+            else {
+                let context = DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Deserialized \(Swift.type(of: T.self)) is not convertible to \(Swift.type(of: U.self))")
+                throw DecodingError.typeMismatch(Swift.type(of: T.self), context)
+            }
+            return castedValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.type = try container.decode(NestedValue.self, forKey: .type)
+            let stringValue: Swift.String = try container.decode(Swift.String.self, forKey: .value)
+            switch T.self {
+                case is Swift.String.Type:
+                    self.value = stringValue as! T
+                case is Swift.Bool.Type:
+                    self.value = try ValueType.castIfPossible {
+                        Swift.Bool(stringValue)
+                    }
+                case is Swift.Double.Type:
+                    self.value = try ValueType.castIfPossible {
+                        Swift.Double(stringValue)
+                    }
+                case is Swift.Int.Type:
+                    self.value = try ValueType.castIfPossible {
+                        Swift.Int(stringValue)
+                    }
+                case is Foundation.Date.Type:
+                    self.value = try ValueType.castIfPossible {
+                        let dateFormatter: ISO8601DateFormatter = .init()
+                        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                        return dateFormatter.date(from: stringValue)
+                    }
+                default:
+                    fatalError("Unexpected value type: \(Swift.type(of: T.self))")
+            }
+        }
+    }
+
+    public struct ResultType: Codable {
+
+        public let name: String
+    }
+
+    public struct SchemaSerializable: Codable {
+
+        public let type: ResultType
+        public let value: String
+    }
+
+    public class Array<T: Codable>: Codable {
+
+        private enum CodingKeys: Swift.String, CodingKey {
+            case values = "_values"
+        }
+
+        public let values: [T]
+
+        required public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.values = try container.decode([T].self, forKey: .values)
+        }
+    }
+}

--- a/src/xcresult/XCResultParser/BUILD
+++ b/src/xcresult/XCResultParser/BUILD
@@ -1,0 +1,23 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "XCResultParser",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "XCResultParser",
+    deps = [
+        "//src/xcresult/XCResultCommands:XCResultTypes_Generated",
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_kylef_pathkit//:PathKit",
+    ],
+)
+
+swift_binary(
+    name = "xcresultparser",
+    deps = [
+        ":XCResultParser",
+    ],
+)

--- a/src/xcresult/XCResultParser/Sources/RootCommand.swift
+++ b/src/xcresult/XCResultParser/Sources/RootCommand.swift
@@ -1,0 +1,120 @@
+import ArgumentParser
+import Foundation
+import PathKit
+import XCResultTypes_Generated
+
+@main
+internal struct RootCommand: ParsableCommand {
+
+    internal enum Error: Swift.Error, CustomStringConvertible {
+        case processFailed(outputString: String, errorString: String, terminationStatus: Int32)
+
+        internal var description: String {
+            switch self {
+                case let .processFailed(outputString: outputString, errorString: errorString, terminationStatus: terminationStatus):
+                    return """
+                        Process failed:
+                        - termination status: \(terminationStatus)
+                        - output: \(outputString)
+                        - error: \(errorString)
+                        """
+            }
+        }
+    }
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "xcresultparser",
+        abstract: "A tool for parsing XCResult files.")
+
+    @Option(name: .long, help: "Path to '.xcresult' file.")
+    internal var xcresultPath: String
+
+    internal func run() throws {
+        let root: XCResultTypes.ActionsInvocationRecord = try parseXCResult()
+        try logTestResults(actionsInvocationRecord: root)
+    }
+
+    private func parseXCResult<T: Codable>(id: String? = nil) throws -> T {
+        let process: Process = .init()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        var arguments: [String] = [
+            "xcresulttool",
+            "get",
+            "--format=json",
+            "--path=\(xcresultPath)"
+        ]
+        if let id = id {
+            arguments.append("--id=\(id)")
+        }
+        process.arguments = arguments
+        let outputPipe: Pipe = .init()
+        let errorPipe: Pipe = .init()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+        let outputData: Data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData: Data = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            throw Error.processFailed(
+                outputString: String(decoding: outputData, as: UTF8.self),
+                errorString: String(decoding: errorData, as: UTF8.self),
+                terminationStatus: process.terminationStatus)
+        }
+        return try JSONDecoder().decode(T.self, from: outputData)
+    }
+
+    private func logTestResults(actionsInvocationRecord: XCResultTypes.ActionsInvocationRecord) throws {
+        guard
+            let actionRecords: [XCResultTypes.ActionRecord] = actionsInvocationRecord.actions?.values,
+            !actionRecords.isEmpty
+        else {
+            print("Missing action records")
+            return
+        }
+        let actionTestPlanRunSummaries: [XCResultTypes.ActionTestPlanRunSummaries] = try actionRecords
+            .compactMap { actionRecord in
+                actionRecord.actionResult?.testsRef?.id?.value
+            }
+            .map { testRefID in
+                try parseXCResult(id: testRefID)
+            }
+        let actionTestableSummaries: [XCResultTypes.ActionTestableSummary] = actionTestPlanRunSummaries
+            .flatMap {
+                $0.summaries?.values ?? []
+            }
+            .flatMap {
+                $0.testableSummaries?.values ?? []
+            }
+        actionTestableSummaries.forEach { testableSummary in
+            let tests: String = (testableSummary.tests?.values ?? []).map {
+                makeTestString(test: $0, iteration: 1)
+            }.joined(separator: "\n")
+            print("""
+            - target: \(testableSummary.targetName?.value ?? "missing")
+              tests:
+            \(tests)
+            """)
+        }
+    }
+
+    private func makeTestString(test: XCResultTypes.ActionTestSummaryGroup, iteration: Int) -> String {
+        let subtests: [XCResultTypes.ActionTestSummaryGroup] = test.subtests?.values ?? []
+        let spacePrefix: String = (0..<iteration).map { _ in "\t" }.joined()
+        while !subtests.isEmpty {
+            let subtests: String = subtests.map {
+                makeTestString(test: $0, iteration: iteration + 1)
+            }.joined(separator: "\n")
+            return """
+                \(spacePrefix)- identifier: \(test.identifier?.value ?? "missing")
+                \(spacePrefix)  duration: \(test.duration?.value ?? -1)
+                \(spacePrefix)  subtests:
+                \(subtests)
+                """
+        }
+        return """
+            \(spacePrefix)- identifier: \(test.identifier?.value ?? "missing")
+            \(spacePrefix)  duration: \(test.duration?.value ?? -1)
+            """
+    }
+}


### PR DESCRIPTION
### Description

Add XCResult infrastructure and an end-to-end demonstration of:
- Flaky test target BEP generation
- XCResult path extraction from BEP
- XCResult parsing from extracted path

This demonstration can be invoked via:
```
make xcresultparser_demo
```

### Notes

The XCResult parser introduced in this exploration has one notable difference as compared to other existing XCResult parsing libraries: **the models are entirely code-generated based on `xcrun xcresulttool formatDescription get` definitions, and virtually no underlying decoding models / implementation are handwritten.**

Given this, however, the parsing is rather inflexible in its current state; types that utilize subclassing (and/or layers of subclassing) are decoded to base classes, resulting in lost type information. A mechanism called `TypeOverrides` has been introduced to partially overcome this issue. This mechanism is defined via YAML, and consumed by a `genrule` to influence the generated parsing models.

### Changelog

- ADDED:
    - Dependencies
        - `com_github_kylef_pathkit`
        - `com_github_stencilproject_stencil`
        - `com_github_jpsim_yams`
    - Targets
        - `XCResultCommands` (integrated in `xcresult` `swift_binary`)
        - `XCResultTypes_Generated`
        - `XCResultParser` (integrated in `xcresultparser` `swift_binary`)
    - `xcresultparser_demo` demo in `Makefile`