### PR TITLE
Test Undeclared Outputs Exploration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,3 +8,6 @@ test:bep_fixture --zip_undeclared_test_outputs=false
 test:bep_fixture --build_event_binary_file=/tmp/bazel/bep
 build:bes_server --bes_backend=grpc://localhost:9000
 build:bes_server --bes_upload_mode=fully_async
+test:test_undeclared_outputs --zip_undeclared_test_outputs=false
+test:test_undeclared_outputs --build_event_binary_file=/tmp/bazel/bep
+

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,13 @@ xcresultparser_demo:
 	bazelisk test //src/bep/Fixtures:ExampleTests --config=bep_fixture && \
 	XCRESULT_PATH=$$(bazelisk run //src/bep/BEPCommands:bep -- extract-xcresult --bep-path=/tmp/bazel/bep) && \
 	bazelisk run //src/xcresult/XCResultParser:xcresultparser -- --xcresult-path=$$XCRESULT_PATH
+
+# [CW] 3/14/23 - This demo can also be invoked with the 'ExampleTests_ios_unit_test' target:
+# e.g. 'make test_undeclared_outputs_demo target=ExampleTests_ios_unit_test'
+.PHONY test_undeclared_outputs_demo:
+test_undeclared_outputs_demo: target ?= ExampleTests_swift_test
+test_undeclared_outputs_demo:
+	bazelisk test //src/test_undeclared_outputs/Example:$(target) -t- --config=test_undeclared_outputs && \
+	git apply src/test_undeclared_outputs/Patches/ExampleTests_isRecording.patch && \
+	bazelisk test //src/test_undeclared_outputs/Example:$(target) -t- --config=test_undeclared_outputs || true && \
+	bazelisk run //src/test_undeclared_outputs/Commands:test-undeclared-outputs -- extract-snapshots --bep-path=/tmp/bazel/bep --workspace-path=$$(pwd)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ A project exploring the use of Bazel and Swift across various use-cases.
 
 - [Build Event Protocol Parsing via Protocol Buffers](src/bep)
 - [XCResult Parsing](src/xcresult)
+- [Test Undeclared Outputs](src/test_undeclared_outputs)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,3 +128,11 @@ http_archive(
     strip_prefix = "Yams-5.0.5",
     url = "https://github.com/jpsim/Yams/archive/refs/tags/5.0.5.tar.gz",
 )
+
+http_archive(
+    name = "com_github_pointfreeco_swift_snapshot_testing",
+    build_file = "swift-snapshot-testing/BUILD",
+    sha256 = "1958ec401eab4fd9c9e659f85641fa29a1d38d2fd6d5cc733e411fabf5324cfa",
+    strip_prefix = "swift-snapshot-testing-1.11.0",
+    url = "https://github.com/pointfreeco/swift-snapshot-testing/archive/refs/tags/1.11.0.tar.gz",
+)

--- a/external/swift-snapshot-testing/BUILD
+++ b/external/swift-snapshot-testing/BUILD
@@ -1,0 +1,17 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "SnapshotTesting",
+    testonly = True,
+    srcs = glob(
+        [
+            "Sources/**/*.swift",
+        ],
+        allow_empty = False,
+    ),
+    module_name = "SnapshotTesting",
+    visibility = ["//visibility:public"],
+)

--- a/src/bep/BEPCommands/Sources/ParseCommand.swift
+++ b/src/bep/BEPCommands/Sources/ParseCommand.swift
@@ -7,26 +7,16 @@ internal struct ParseCommand: ParsableCommand {
         commandName: "parse",
         abstract: "A tool for parsing Bazel Build Event Protocol binary files.")
 
+    @Option(help: "Path to BEP file.")
+    internal var bepPath: String
+
     internal func run() throws {
-        print("ParseCommand")
-        let bepPath: String = "/Users/connorwybranowski/Downloads/ExampleTests_flaky_bep"
         let parser: BEPParserImp = .init()
-        let flakyTestTargetMap: FlakyTestTargetMapImp = .init()
-        let flakyTargets: [FlakyTestTarget] = flakyTestTargetMap.map(
-            events: try parser.readEvents(bepPath: bepPath))
-        print("Found \(flakyTargets.count) flaky test targets:")
-        flakyTargets.forEach {
-            print("""
-            - label: \($0.label)
-              runsPerTest: \($0.runsPerTest)
-              totalRunCount: \($0.totalRunCount)
-              passedCount: \($0.passedCount)
-              failedCount: \($0.failedCount)
-              wallTimeDurationMillis: \($0.wallTimeDurationMillis)
-              systemTimeDurationMillis: \($0.systemTimeDurationMillis)
-              failedRunArtifactPaths:
-            \($0.failedRunArtifactPaths.map { "\t- \($0)" }.joined(separator: "\n"))
-            """)
+        let buildEvents = try parser.readEvents(bepPath: bepPath)
+        buildEvents.forEach { event in
+            event.namedSetOfFiles.files.forEach { file in
+                print("- \(file)")
+            }
         }
     }
 }

--- a/src/test_undeclared_outputs/Commands/BUILD
+++ b/src/test_undeclared_outputs/Commands/BUILD
@@ -1,0 +1,25 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "TestUndeclaredOutputsCommands",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "TestUndeclaredOutputsCommands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/bep/BEPCore",
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_kylef_pathkit//:PathKit",
+    ],
+)
+
+swift_binary(
+    name = "test-undeclared-outputs",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":TestUndeclaredOutputsCommands",
+    ],
+)

--- a/src/test_undeclared_outputs/Commands/Sources/ExtractSnapshotsCommand.swift
+++ b/src/test_undeclared_outputs/Commands/Sources/ExtractSnapshotsCommand.swift
@@ -1,0 +1,92 @@
+import ArgumentParser
+import BEPCore
+import PathKit
+
+internal struct ExtractSnapshotsCommand: ParsableCommand {
+
+    internal enum Error: Swift.Error, CustomStringConvertible {
+        case missingTestOutputs
+        case missingAssertSnapshot(path: String)
+        case missingPathComponent(path: String, expectedComponent: String)
+
+        internal var description: String {
+            switch self {
+            case .missingTestOutputs:
+                return "Missing 'test.outputs' directory in BEP file"
+            case let .missingAssertSnapshot(path: path):
+                return "Missing 'assert_snapshot' child directory in path: \(path)"
+            case let .missingPathComponent(path: path, expectedComponent: expectedComponent):
+                return """
+                    Missing component in path:
+                    - path: \(path)
+                    - expected component: \(expectedComponent)
+                    """
+            }
+        }
+    }
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "extract-snapshots",
+        abstract: "A tool for extracting recorded snapshot artifacts from 'TEST_UNDECLARED_OUTPUTS_DIR' found in a Bazel BEP binary file.")
+
+    @Option(help: "Path to BEP file.")
+    internal var bepPath: String
+
+    @Option(help: "Path to local workspace to extract snapshots.")
+    internal var workspacePath: String
+
+    internal func run() throws {
+        let parser: BEPParserImp = .init()
+        let buildEvents = try parser.readEvents(bepPath: bepPath)
+        let testOutputsPaths: [Path] = buildEvents
+            .map(\.testResult)
+            .flatMap(\.testActionOutput)
+            .filter {
+                $0.name == "test.outputs"
+            }
+            .map {
+                parseURI(uri: $0.uri)
+            }
+        guard !testOutputsPaths.isEmpty else {
+            throw Error.missingTestOutputs
+        }
+        let firstTestOutputPath: Path = testOutputsPaths[0]
+        let assertSnapshotPath: Path = firstTestOutputPath + "assert_snapshot"
+        guard assertSnapshotPath.exists else {
+            throw Error.missingAssertSnapshot(path: firstTestOutputPath.string)
+        }
+        try assertSnapshotPath.recursiveChildren()
+            .filter {
+                $0.isFile
+            }
+            .forEach { path in
+                let destinationPath: Path = try Path(workspacePath) + makeRelativePath(path: path)
+                try destinationPath.parent().mkpath()
+                if destinationPath.exists {
+                    try destinationPath.delete()
+                }
+                try path.copy(destinationPath)
+        }
+    }
+
+    private func parseURI(uri: String) -> Path {
+        let prefix: String = "file://"
+        if uri.hasPrefix(prefix) {
+            return Path(String(uri.dropFirst(prefix.count)))
+        } else {
+            return Path(uri)
+        }
+    }
+
+    private func makeRelativePath(path: Path) throws -> Path {
+        let assertSnapshotComponent: String = "assert_snapshot"
+        guard let assertSnapshotIndex: Int = path.components.firstIndex(where: {
+            $0 == assertSnapshotComponent
+        }) else {
+            throw Error.missingPathComponent(
+                path: path.string,
+                expectedComponent: assertSnapshotComponent)
+        }
+        return Path(components: path.components[assertSnapshotIndex + 1..<path.components.count])
+    }
+}

--- a/src/test_undeclared_outputs/Commands/Sources/RootCommand.swift
+++ b/src/test_undeclared_outputs/Commands/Sources/RootCommand.swift
@@ -1,0 +1,11 @@
+import ArgumentParser
+
+@main
+internal struct RootCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        abstract: "A tool for 'TEST_UNDECLARED_OUTPUTS_DIR' utilities.",
+        subcommands: [
+            ExtractSnapshotsCommand.self
+        ])
+}

--- a/src/test_undeclared_outputs/Example/BUILD
+++ b/src/test_undeclared_outputs/Example/BUILD
@@ -1,0 +1,56 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+    "swift_test",
+)
+load(
+    "@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_unit_test",
+)
+
+filegroup(
+    name = "ExampleTests_Snapshots",
+    srcs = glob(
+        [
+            "__Snapshots__/**/*",
+        ],
+        allow_empty = False,
+    ),
+)
+
+# [CW] 3/13/23 - 'swift_test' automatically propagates 'TEST_UNDECLARED_OUTPUTS_DIR' and 'env.RUNFILES_DIR' to the
+# process environment, without explicitly setting the 'env' (see the 'ios_unit_test' target below).
+swift_test(
+    name = "ExampleTests_swift_test",
+    testonly = True,
+    srcs = ["Tests/ExampleTests.swift"],
+    data = [":ExampleTests_Snapshots"],
+    deps = [
+        "//src/test_undeclared_outputs/TestKit",
+    ],
+)
+
+swift_library(
+    name = "ExampleTestsLib",
+    testonly = True,
+    srcs = ["Tests/ExampleTests.swift"],
+    deps = [
+        "//src/test_undeclared_outputs/TestKit",
+    ],
+)
+
+# [CW] 3/13/23 - Unlike the 'swift_test' target, 'env.TEST_UNDECLARED_OUTPUTS_DIR' and 'env.RUNFILES_DIR' must be
+# explicitly defined to propagate to the process environment.
+ios_unit_test(
+    name = "ExampleTests_ios_unit_test",
+    data = [":ExampleTests_Snapshots"],
+    env = {
+        "TEST_UNDECLARED_OUTPUTS_DIR": "$TEST_UNDECLARED_OUTPUTS_DIR",
+        "RUNFILES_DIR": "$RUNFILES_DIR",
+    },
+    minimum_os_version = "16.0",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    deps = [
+        ":ExampleTestsLib",
+    ],
+)

--- a/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift
+++ b/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift
@@ -1,0 +1,13 @@
+import TestKit
+import XCTest
+
+class ExampleTests: XCTestCase {
+
+    func testExample() throws {
+        // GIVEN
+        let subject: String = "subject"
+
+        // THEN
+        assertSnapshot(matching: subject, as: .lines)
+    }
+}

--- a/src/test_undeclared_outputs/Example/__Snapshots__/ExampleTests/testExample.1.txt
+++ b/src/test_undeclared_outputs/Example/__Snapshots__/ExampleTests/testExample.1.txt
@@ -1,0 +1,1 @@
+subject

--- a/src/test_undeclared_outputs/Patches/ExampleTests_isRecording.patch
+++ b/src/test_undeclared_outputs/Patches/ExampleTests_isRecording.patch
@@ -1,0 +1,14 @@
+diff --git a/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift b/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift
+index 98326b9..984029d 100644
+--- a/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift
++++ b/src/test_undeclared_outputs/Example/Tests/ExampleTests.swift
+@@ -5,7 +5,8 @@ class ExampleTests: XCTestCase {
+
+     func testExample() throws {
+         // GIVEN
+-        let subject: String = "subject"
++        isRecording = true
++        let subject: String = "subject_2"
+
+         // THEN
+         assertSnapshot(matching: subject, as: .lines)

--- a/src/test_undeclared_outputs/README.md
+++ b/src/test_undeclared_outputs/README.md
@@ -1,0 +1,26 @@
+# Test Undeclared Outputs Exploration
+
+This project explores the use of `TEST_UNDECLARED_OUTPUTS_DIR` and `RUNFILES_DIR`. Specifically, it demonstrates the utility of these ENV values in building a hermetic snapshot recording / validation workflow.
+
+## Infrastructure
+
+- [AssertSnapshot](TestKit/Sources/AssertSnapshot.swift)
+    - Utility for recording / validating snapshot tests using [pointfreeco/swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing)
+    - [`TEST_UNDECLARED_OUTPUTS_DIR`-based](TestKit/Sources/AssertSnapshot.swift#L68) path building for recording test runs (e.g. developer updates local snapshot)
+    - [`RUNFILES_DIR`-based](TestKit/Sources/AssertSnapshot.swift#L70) path building for non-recording test runs (e.g. CI runs snapshot test)
+- [ExtractSnapshotsCommand](Commands/Sources/ExtractSnapshotsCommand.swift)
+    - Command for extracting recorded snapshot artifacts from `TEST_UNDECLARED_OUTPUTS_DIR` found in a Bazel BEP binary file
+
+## Demo
+
+A codified demonstration of this exploration can be executed via:
+
+```
+make test_undeclared_outputs_demo
+```
+
+This demonstration performs the following steps:
+- Run tests with `isRecording = false` (to validate that they pass with the current snapshot)
+- Apply git patch to influence snapshot output
+- Run tests with `isRecording = true`
+- Invoke `test-undeclared-outputs extract-snapshots` command to find newly recorded snapshot outputs in the BEP, and copy back to local repository

--- a/src/test_undeclared_outputs/TestKit/BUILD
+++ b/src/test_undeclared_outputs/TestKit/BUILD
@@ -1,0 +1,21 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "TestKit",
+    testonly = True,
+    srcs = glob(
+        [
+            "Sources/**/*.swift",
+        ],
+        allow_empty = False,
+    ),
+    module_name = "TestKit",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_kylef_pathkit//:PathKit",
+        "@com_github_pointfreeco_swift_snapshot_testing//:SnapshotTesting",
+    ],
+)

--- a/src/test_undeclared_outputs/TestKit/Sources/AssertSnapshot.swift
+++ b/src/test_undeclared_outputs/TestKit/Sources/AssertSnapshot.swift
@@ -1,0 +1,119 @@
+import Foundation
+import PathKit
+import SnapshotTesting
+import XCTest
+
+public var isRecording: Bool {
+    get {
+        SnapshotTesting.isRecording
+    }
+    set {
+        SnapshotTesting.isRecording = newValue
+    }
+}
+
+private enum AssertSnapshotError: Error, CustomStringConvertible {
+    case missingEnvironmentKey(key: String)
+    case missingPathComponent(path: String, expectedComponent: String)
+
+    var description: String {
+        switch self {
+        case let .missingEnvironmentKey(key: key):
+            return "Missing key in environment: '\(key)'"
+        case let .missingPathComponent(path: path, expectedComponent: expectedComponent):
+            return """
+                Missing component in path:
+                - path: \(path)
+                - expected component: \(expectedComponent)
+                """
+        }
+    }
+}
+
+public func assertSnapshot<Value, Format>(
+    matching value: @autoclosure () throws -> Value,
+    as snapshotting: Snapshotting<Value, Format>,
+    named name: String? = nil,
+    record recording: Bool = false,
+    timeout: TimeInterval = 5,
+    file: StaticString = #file,
+    testName: String = #function,
+    line: UInt = #line
+) {
+    do {
+        let snapshotDirectory: Path = try makeSnapshotDirectory(
+            file: file,
+            recording: recording || SnapshotTesting.isRecording)
+        let failure = verifySnapshot(
+            matching: try value(),
+            as: snapshotting,
+            named: name,
+            record: recording,
+            snapshotDirectory: snapshotDirectory.string,
+            timeout: timeout,
+            file: file,
+            testName: testName)
+        guard let message = failure else { return }
+        XCTFail(message, file: file, line: line)
+    } catch {
+        XCTFail("\(error)", file: file, line: line)
+    }
+ }
+
+private func makeSnapshotDirectory(
+    file: StaticString,
+    recording: Bool
+) throws -> Path {
+    if recording {
+        return try makeRecordingDirectory(file: file)
+    } else {
+        return try makeNonRecordingDirectory(file: file)
+    }
+}
+
+ private func makeRecordingDirectory(file: StaticString) throws -> Path {
+    let testUndeclaredOutputsDir: String = try environmentValue(key: "TEST_UNDECLARED_OUTPUTS_DIR")
+    let assertSnapshotPath: Path = Path(testUndeclaredOutputsDir) + "assert_snapshot"
+    let filePath: Path = Path("\(file)")
+    let snapshotResourcePath: Path = try makePrefixPath(
+        path: filePath,
+        delimiterComponent: "Tests")
+    let finalPath: Path = assertSnapshotPath
+        + snapshotResourcePath
+        + "__Snapshots__"
+        + filePath.lastComponentWithoutExtension
+    try finalPath.mkpath()
+    return finalPath
+}
+
+private func makeNonRecordingDirectory(file: StaticString) throws -> Path {
+    let runfilesDir: String = try environmentValue(key: "RUNFILES_DIR")
+    let runfilesDirPath: Path = Path(runfilesDir)
+    let filePath: Path = Path("\(file)")
+    let snapshotResourcePath: Path = try makePrefixPath(
+        path: filePath,
+        delimiterComponent: "Tests")
+    return runfilesDirPath
+        + "__main__"
+        + snapshotResourcePath
+        + "__Snapshots__"
+        + filePath.lastComponentWithoutExtension
+}
+
+private func makePrefixPath(path: Path, delimiterComponent: String) throws -> Path {
+    guard let componentIndex: Int = path.components.firstIndex(where: {
+        $0 == delimiterComponent
+    }) else {
+        throw AssertSnapshotError.missingPathComponent(
+            path: path.string,
+            expectedComponent: delimiterComponent)
+    }
+    return Path(components: path.components[0..<componentIndex])
+}
+
+private func environmentValue(key: String) throws -> String {
+    guard let value: String = ProcessInfo.processInfo.environment[key] else {
+        throw AssertSnapshotError.missingEnvironmentKey(key: key)
+    }
+    return value
+}


### PR DESCRIPTION
### Description

Add infrastructure for incorporating `TEST_UNDECLARED_OUTPUTS_DIR` and `RUNFILES_DIR` in a hermetic snapshot workflow.

This demonstration can be invoked via:
```
make test_undeclared_outputs_demo
```

### Changelog

- ADDED:
    - Dependencies
        - `com_github_pointfreeco_swift_snapshot_testing`
    - Targets
        - `TestKit` with `AssertSnapshot` utility
        - `ExampleTests_swift_test` and `ExampleTests_ios_unit_test` tests
        - `TestUndeclaredOutputsCommands`
        - `test-undeclared-outputs`
    - `test_undeclared_outputs_demo` demo in `Makefile`
- IMPROVED:
    - `ParseCommand` with `bepPath` parameter