### PR TITLE
Add Health Service

### DIFF
--- a/src/bep/BESServer/BUILD
+++ b/src/bep/BESServer/BUILD
@@ -25,6 +25,33 @@ swift_grpc_library(
     deps = [":publish_build_event_proto_swift"],
 )
 
+proto_library(
+    name = "health_proto",
+    srcs = ["Health/health.proto"],
+)
+
+swift_proto_library(
+    name = "health_proto_swift",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":health_proto",
+    ],
+)
+
+swift_grpc_library(
+    name = "health_server_services_swift",
+    srcs = [":health_proto"],
+    flavor = "server",
+    deps = [":health_proto_swift"],
+)
+
+swift_grpc_library(
+    name = "health_client_services_swift",
+    srcs = [":health_proto"],
+    flavor = "client",
+    deps = [":health_proto_swift"],
+)
+
 swift_library(
     name = "BESServer",
     srcs = glob(["Sources/**/*.swift"]),

--- a/src/bep/BESServer/BUILD
+++ b/src/bep/BESServer/BUILD
@@ -57,6 +57,7 @@ swift_library(
     srcs = glob(["Sources/**/*.swift"]),
     module_name = "BESServer",
     deps = [
+        ":health_server_services_swift",
         ":publish_build_event_server_services_swift",
         "//src/bep/BEPCore",
         "//src/bep/BEPCore:BEP_Protos",
@@ -73,9 +74,19 @@ swift_binary(
 
 xcodeproj(
     name = "project",
+    bazel_path = "/usr/local/bin/bazelisk",
     project_name = "project",
     tags = ["manual"],
     top_level_targets = [
         ":publish_build_event_server",
+        ":sandbox",
+    ],
+)
+
+swift_binary(
+    name = "sandbox",
+    srcs = ["Sandbox/main.swift"],
+    deps = [
+        ":health_client_services_swift",
     ],
 )

--- a/src/bep/BESServer/Health/health.proto
+++ b/src/bep/BESServer/Health/health.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+// [CW] 6/26/23 - Based on the following example:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+  string pid = 2;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+}

--- a/src/bep/BESServer/Sandbox/main.swift
+++ b/src/bep/BESServer/Sandbox/main.swift
@@ -1,0 +1,21 @@
+import GRPC
+import src_bep_BESServer_health_client_services_swift
+import src_bep_BESServer_health_proto
+
+let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
+defer {
+    try? group.syncShutdownGracefully()
+}
+
+let channel = try GRPCChannelPool.with(
+    target: .host("localhost", port: 9000),
+    transportSecurity: .plaintext,
+    eventLoopGroup: group)
+
+let health = Grpc_Health_V1_HealthClient(channel: channel)
+let request: Grpc_Health_V1_HealthCheckRequest = .init()
+let response = health.check(
+    request,
+    callOptions: .init(timeLimit: .timeout(.milliseconds(100))))
+let output = try response.response.wait()
+print("output: \(output.status) (\(output.pid))")

--- a/src/bep/BESServer/Sources/Providers/Health/HealthProvider.swift
+++ b/src/bep/BESServer/Sources/Providers/Health/HealthProvider.swift
@@ -1,0 +1,21 @@
+import Foundation
+import GRPC
+import NIO
+import src_bep_BESServer_health_proto
+import src_bep_BESServer_health_server_services_swift
+import SwiftProtobuf
+
+class HealthProviderImp: Grpc_Health_V1_HealthProvider {
+
+    var interceptors: Grpc_Health_V1_HealthServerInterceptorFactoryProtocol? = HealthServerInterceptorFactory()
+
+    func check(
+        request: Grpc_Health_V1_HealthCheckRequest,
+        context: StatusOnlyCallContext
+    ) -> EventLoopFuture<Grpc_Health_V1_HealthCheckResponse> {
+        context.eventLoop.makeSucceededFuture(.with {
+            $0.status = .serving
+            $0.pid = "\(ProcessInfo.processInfo.processIdentifier)"
+        })
+    }
+}

--- a/src/bep/BESServer/Sources/Providers/Health/HealthServerInterceptorFactory.swift
+++ b/src/bep/BESServer/Sources/Providers/Health/HealthServerInterceptorFactory.swift
@@ -1,0 +1,10 @@
+import GRPC
+import src_bep_BESServer_health_proto
+import src_bep_BESServer_health_server_services_swift
+import SwiftProtobuf
+
+class HealthServerInterceptorFactory: Grpc_Health_V1_HealthServerInterceptorFactoryProtocol {
+    func makeCheckInterceptors() -> [ServerInterceptor<Grpc_Health_V1_HealthCheckRequest, Grpc_Health_V1_HealthCheckResponse>] {
+        []
+    }
+}

--- a/src/bep/BESServer/Sources/PublishBuildEventServer.swift
+++ b/src/bep/BESServer/Sources/PublishBuildEventServer.swift
@@ -7,9 +7,12 @@ public enum PublishBuildEventServer {
         // [CW] 2/20/23 - Based on:
         // https://github.com/grpc/grpc-swift/blob/main/Sources/Examples/Echo/Runtime/Echo.swift#L120
         let builder: Server.Builder = Server.insecure(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
-        let server = try await builder.withServiceProviders([PublishBuildEventProviderImp()])
-            .bind(host: "localhost", port: 9000)
-            .get()
+        let server = try await builder.withServiceProviders([
+            PublishBuildEventProviderImp(),
+            HealthProviderImp()
+        ])
+        .bind(host: "localhost", port: 9000)
+        .get()
         print("Started BES server: \(server.channel.localAddress!)")
         try await server.onClose.get()
     }

--- a/src/bep/README.md
+++ b/src/bep/README.md
@@ -6,3 +6,4 @@
     - [BESServer](BESServer/Sources/PublishBuildEventServer.swift)
     - [BuildEventServerInterceptor](BESServer/Sources/Interceptors/BuildEventServerInterceptor.swift): Capture `BuildEventStream_BuildEvent` from `Google_Devtools_Build_V1_PublishBuildToolEventStreamRequest` and store in `UserInfo` for use in future interceptors.
     - [FlakyTestTargetServerInterceptor](BESServer/Sources/Interceptors/FlakyTestTargetServerInterceptor.swift): Consume `UserInfo`-stored `BuildEventStream_BuildEvent` to detect flaky tests in streamed builds.
+    - [Health](BESServer/Health/health.proto) proto service: Facilitate health check to obtain status and PID of BES.


### PR DESCRIPTION
### Description

Add `health.proto` health check service to allow clients to understand the status / PID of the BES process.

**Note:** This implementation is based on [this example](https://github.com/grpc/grpc/blob/master/doc/health-checking.md).

### Changelog

- ADDED:
    - `health.proto`
    - `proto_library`, `swift_proto_library`, and `swift_grpc_library` targets for health service
    - `sandbox` health client
- IMPROVED:
    - Integrate `health_server_services_swift` in `BESServer`
    - Integrate `HealthProviderImp` in `PublishBuildEventServer`
    - README