### PR TITLE
Bazel Credential Helper

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,4 +10,5 @@ build:bes_server --bes_backend=grpc://localhost:9000
 build:bes_server --bes_upload_mode=fully_async
 test:test_undeclared_outputs --zip_undeclared_test_outputs=false
 test:test_undeclared_outputs --build_event_binary_file=/tmp/bazel/bep
-
+sync:credential_helper --credential_helper=*.github.com=%workspace%/demo/credential-helper
+sync:credential_helper --credential_helper_cache_duration=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
 *.xcodeproj
+demo

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,16 @@ test_undeclared_outputs_demo:
 	git apply src/test_undeclared_outputs/Patches/ExampleTests_isRecording.patch && \
 	bazelisk test //src/test_undeclared_outputs/Example:$(target) -t- --config=test_undeclared_outputs || true && \
 	bazelisk run //src/test_undeclared_outputs/Commands:test-undeclared-outputs -- extract-snapshots --bep-path=/tmp/bazel/bep --workspace-path=$$(pwd)
+
+# [CW] 9/10/23 - This demo requires a GitHub Private Repository and GitHub Access Token to function as expected.
+.PHONY credential_helper_demo:
+credential_helper_demo: github_access_token ?= placeholder
+credential_helper_demo:
+	rm -rf demo && \
+	mkdir -p demo && \
+	bazelisk build //src/credential_helper/CredentialHelperCommands:credential-helper && \
+	cp bazel-bin/src/credential_helper/CredentialHelperCommands/credential-helper demo && \
+	bazelisk sync --only=com_github_bazel_swift_private_repository --config=credential_helper || true && \
+	echo $(github_access_token) > demo/credentials.txt && \
+	bazelisk sync --only=com_github_bazel_swift_private_repository --config=credential_helper && \
+	rm -rf demo

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A project exploring the use of Bazel and Swift across various use-cases.
 - [Build Event Protocol Parsing via Protocol Buffers](src/bep)
 - [XCResult Parsing](src/xcresult)
 - [Test Undeclared Outputs](src/test_undeclared_outputs)
+- [Bazel Credential Helper](src/credential_helper)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,3 +136,9 @@ http_archive(
     strip_prefix = "swift-snapshot-testing-1.11.0",
     url = "https://github.com/pointfreeco/swift-snapshot-testing/archive/refs/tags/1.11.0.tar.gz",
 )
+
+http_archive(
+    name = "com_github_bazel_swift_private_repository",
+    strip_prefix = "bazel-swift-private-repository-9f5f94a816618498c4f5bdae56b6ef2ce754ed61",
+    url = "https://github.com/cwybro/bazel-swift-private-repository/archive/9f5f94a816618498c4f5bdae56b6ef2ce754ed61.zip",
+)

--- a/src/credential_helper/CredentialHelperCommands/BUILD
+++ b/src/credential_helper/CredentialHelperCommands/BUILD
@@ -1,0 +1,24 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "CredentialHelperCommands",
+    srcs = glob(["Sources/**/*.swift"]),
+    module_name = "CredentialHelperCommands",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_kylef_pathkit//:PathKit",
+    ],
+)
+
+swift_binary(
+    name = "credential-helper",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":CredentialHelperCommands",
+    ],
+)

--- a/src/credential_helper/CredentialHelperCommands/Sources/GetCommand.swift
+++ b/src/credential_helper/CredentialHelperCommands/Sources/GetCommand.swift
@@ -1,0 +1,40 @@
+import ArgumentParser
+import Foundation
+import PathKit
+
+internal final class GetCommand: ParsableCommand {
+
+    private struct GetInput: Codable {
+        internal let uri: String
+    }
+
+    private struct GetOutput: Codable {
+        internal let headers: [String: [String]]
+    }
+
+    internal static let configuration: CommandConfiguration = .init(
+        commandName: "get",
+        abstract: "A tool for obtaining credentials, per https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md.")
+
+    internal func run() throws {
+        let accessToken: String = try makeAccessToken().trimmingCharacters(in: .whitespacesAndNewlines)
+        let output: GetOutput = .init(
+            headers: [
+                "Authorization": [
+                    "token \(accessToken)"
+                ],
+            ]
+        )
+        print(
+            String(
+                decoding: try JSONEncoder().encode(output),
+                as: UTF8.self
+            )
+        )
+    }
+
+    private func makeAccessToken() throws -> String {
+        let path: Path = .current + "demo" + "credentials.txt"
+        return try path.read()
+    }
+}

--- a/src/credential_helper/CredentialHelperCommands/Sources/RootCommand.swift
+++ b/src/credential_helper/CredentialHelperCommands/Sources/RootCommand.swift
@@ -1,0 +1,11 @@
+import ArgumentParser
+
+@main
+internal struct RootCommand: ParsableCommand {
+
+    internal static let configuration: CommandConfiguration = .init(
+        abstract: "A tool for Bazel Credential Helper utilities.",
+        subcommands: [
+            GetCommand.self
+        ])
+}

--- a/src/credential_helper/README.md
+++ b/src/credential_helper/README.md
@@ -1,0 +1,3 @@
+# Bazel Credential Helper Exploration
+
+An exploration based on the [`2022-06-07-bazel-credential-helpers.md` bazelbuild proposal](https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md).


### PR DESCRIPTION
### Description

Add `credential-helper` and supporting targets to demonstrate the integration and use of a [Bazel Credential Helper](https://github.com/bazelbuild/proposals/blob/main/designs/2022-06-07-bazel-credential-helpers.md). The demo, which can be invoked via `make credential_helper_demo` (after providing a private repository and valid GitHub Access Token) illustrates how the helper can be used to provide authenticated access to a GitHub Private Repository via plain `http_archive`, through mechanisms other than `.netrc`.

### Changelog
- ADDED:
    - `CredentialHelperCommands` and `credential-helper` targets
    - `make credential_helper_demo`
- IMPROVED:
    - Update `.gitignore`
    - Update `README`