### PR TITLE
Add apple/swift-format

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,3 +165,11 @@ http_archive(
     strip_prefix = "swift-syntax-509.0.0",
     url = "https://github.com/apple/swift-syntax/archive/refs/tags/509.0.0.tar.gz",
 )
+
+http_archive(
+    name = "com_github_apple_swift_format",
+    build_file = "com_github_apple_swift_format/BUILD",
+    sha256 = "3041b470f6de7c156cf5898bc59645073c29def8dea66f9f356681163cae371e",
+    strip_prefix = "swift-format-509.0.0",
+    url = "https://github.com/apple/swift-format/archive/refs/tags/509.0.0.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -150,3 +150,11 @@ http_archive(
     strip_prefix = "swift-cmark-0.2.0",
     url = "https://github.com/apple/swift-cmark/archive/refs/tags/0.2.0.tar.gz",
 )
+
+http_archive(
+    name = "com_github_apple_swift_markdown",
+    build_file = "com_github_apple_swift_markdown/BUILD",
+    sha256 = "0648c94b8ed5412591d48aee69a22a853062751b219d29426c8c4616b587f1aa",
+    strip_prefix = "swift-markdown-0.2.0",
+    url = "https://github.com/apple/swift-markdown/archive/refs/tags/0.2.0.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,3 +142,11 @@ http_archive(
     strip_prefix = "bazel-swift-private-repository-9f5f94a816618498c4f5bdae56b6ef2ce754ed61",
     url = "https://github.com/cwybro/bazel-swift-private-repository/archive/9f5f94a816618498c4f5bdae56b6ef2ce754ed61.zip",
 )
+
+http_archive(
+    name = "com_github_apple_swift_cmark",
+    build_file = "com_github_apple_swift_cmark/BUILD",
+    sha256 = "f22968ffca65bf23c888b48a3dffe16d01bd3a4fc7b37832ffa3a9ad729bcc5e",
+    strip_prefix = "swift-cmark-0.2.0",
+    url = "https://github.com/apple/swift-cmark/archive/refs/tags/0.2.0.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,3 +158,10 @@ http_archive(
     strip_prefix = "swift-markdown-0.2.0",
     url = "https://github.com/apple/swift-markdown/archive/refs/tags/0.2.0.tar.gz",
 )
+
+http_archive(
+    name = "com_github_apple_swift_syntax",
+    sha256 = "1cddda9f7d249612e3d75d4caa8fd9534c0621b8a890a7d7524a4689bce644f1",
+    strip_prefix = "swift-syntax-509.0.0",
+    url = "https://github.com/apple/swift-syntax/archive/refs/tags/509.0.0.tar.gz",
+)

--- a/external/com_github_apple_swift_cmark/BUILD
+++ b/external/com_github_apple_swift_cmark/BUILD
@@ -1,0 +1,64 @@
+cc_library(
+    name = "cmark-gfm",
+    srcs = glob(
+        [
+            "src/*",
+        ],
+        [
+            "src/scanners.re",
+            "src/libcmark-gfm.pc.in",
+            "src/config.h.in",
+            "src/CMakeLists.txt",
+            "src/cmark-gfm_version.h.in",
+            # [CW] 2/16/24 - Must be included, despite the configuration here:
+            # https://github.com/apple/swift-cmark/blob/0.2.0/Package.swift#L56
+            # "src/case_fold_switch.inc",
+            # "src/entities.inc",
+        ],
+        allow_empty = False,
+    ),
+    hdrs = glob(
+        [
+            "src/include/*.h",
+        ],
+        allow_empty = False,
+    ),
+    includes = [
+        "src/include",
+    ],
+    visibility = [
+        "@com_github_apple_swift_markdown//:__pkg__",
+    ],
+)
+
+cc_library(
+    name = "cmark-gfm-extensions",
+    srcs = glob(
+        [
+            "extensions/*",
+        ],
+        [
+            "extensions/CMakeLists.txt",
+            "extensions/ext_scanners.re",
+        ],
+        allow_empty = False,
+    ),
+    hdrs = glob(
+        [
+            "extensions/include/*.h",
+        ],
+        allow_empty = False,
+    ),
+    includes = [
+        "extensions/include",
+    ],
+    tags = [
+        "swift_module=cmark_gfm_extensions",
+    ],
+    visibility = [
+        "@com_github_apple_swift_markdown//:__pkg__",
+    ],
+    deps = [
+        ":cmark-gfm",
+    ],
+)

--- a/external/com_github_apple_swift_format/BUILD
+++ b/external/com_github_apple_swift_format/BUILD
@@ -1,0 +1,45 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "SwiftFormat",
+    srcs = glob(
+        [
+            "Sources/SwiftFormat/**/*.swift",
+        ],
+        allow_empty = False,
+    ),
+    module_name = "SwiftFormat",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "@com_github_apple_swift_markdown//:Markdown",
+        "@com_github_apple_swift_syntax//:SwiftOperators",
+        "@com_github_apple_swift_syntax//:SwiftParser",
+        "@com_github_apple_swift_syntax//:SwiftParserDiagnostics",
+        "@com_github_apple_swift_syntax//:SwiftSyntax",
+    ],
+)
+
+swift_binary(
+    name = "swift-format",
+    srcs = glob(
+        [
+            "Sources/swift-format/**/*.swift",
+        ],
+        allow_empty = False,
+    ),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":SwiftFormat",
+        "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_apple_swift_syntax//:SwiftParser",
+        "@com_github_apple_swift_syntax//:SwiftSyntax",
+    ],
+)

--- a/external/com_github_apple_swift_markdown/BUILD
+++ b/external/com_github_apple_swift_markdown/BUILD
@@ -1,0 +1,45 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "Markdown",
+    srcs = glob(
+        [
+            "Sources/Markdown/**/*.swift",
+        ],
+        allow_empty = False,
+    ),
+    module_name = "Markdown",
+    visibility = [
+        "@com_github_apple_swift_format//:__pkg__",
+    ],
+    deps = [
+        ":CAtomic",
+        "@com_github_apple_swift_cmark//:cmark-gfm",
+        "@com_github_apple_swift_cmark//:cmark-gfm-extensions",
+    ],
+)
+
+cc_library(
+    name = "CAtomic",
+    srcs = glob(
+        [
+            "Sources/CAtomic/*",
+        ],
+        allow_empty = False,
+    ),
+    hdrs = glob(
+        [
+            "Sources/CAtomic/include/*.h",
+        ],
+        allow_empty = False,
+    ),
+    includes = [
+        "Sources/CAtomic/include",
+    ],
+    tags = [
+        "swift_module=CAtomic",
+    ],
+)


### PR DESCRIPTION
### Description

Add [apple/swift-format](https://github.com/apple/swift-format) to the toolchain. This is a build-from-source external dependency accessible for [command-line usage](https://github.com/apple/swift-format?tab=readme-ov-file#command-line-usage) via:
```
bazelisk run @com_github_apple_swift_format//:swift-format 
```

Or via the [Swift API](https://github.com/apple/swift-format?tab=readme-ov-file#api-usage) by adding the following dependency:
```
@com_github_apple_swift_format//:SwiftFormat
```